### PR TITLE
Avoid executing openapi plugin during docker dependency step

### DIFF
--- a/source/rest-service/pom.xml
+++ b/source/rest-service/pom.xml
@@ -148,6 +148,7 @@
               <goal>generate</goal>
             </goals>
             <configuration>
+              <skip>${maven.main.skip}</skip>
               <!-- Location of our openapi specification file -->
               <inputSpec>${project.basedir}/src/main/resources/static/api.yaml</inputSpec>
               <!-- Type of code to generate -->


### PR DESCRIPTION
The build would break in docker because it would expect the api.yaml to be available (and that is copied later)
Were 2 solutions as far as I could see: adding the api.yaml or preventing the need for it. Since in this step we only want to download dependencies so we don't have to do that each time this seems the cleaner approach.