### PR TITLE
AER-2219 Units inland shipping EF in DB

### DIFF
--- a/source/database/src/main/sql/template/02-emission_factors/02-tables/shipping_inland.sql
+++ b/source/database/src/main/sql/template/02-emission_factors/02-tables/shipping_inland.sql
@@ -42,7 +42,7 @@ CREATE TABLE shipping_inland_waterway_categories
  * Deze factoren zijn uniek per scheepstype, vaarwegtype, vaarrichtingen, ladingstoestand en stof.
  *
  * Hierin worden de emissiefactoren per jaar weergegeven, emission_factor is de emissie factor tijdens 
- * varen (in kg/(kilometer * aantal schepen)) bij een bepaalde snelheid.
+ * varen (in g/(kilometer * aantal schepen)) bij een bepaalde snelheid.
  */
 CREATE TABLE shipping_inland_category_emission_factors
 (
@@ -68,7 +68,7 @@ CREATE TABLE shipping_inland_category_emission_factors
  * Deze kenmerken zijn uniek per scheepstype, ladingstoestand en stof.
  *
  * Hierin worden de emissiefactoren per jaar weergegeven, emission_factor is de emissie factor tijdens 
- * varen (in kg/(kilometer * aantal schepen)) bij een bepaalde snelheid.
+ * stilliggen (in g/(uur * aantal schepen)).
  */
 CREATE TABLE shipping_inland_category_emission_factors_docked
 (


### PR DESCRIPTION
Updated documentation for units for inland shipping emission factors. Change was already done on AERIUS-II.

Values are not yet read from database, but should be taken into account when designing the actual service for this part. 
In AERIUS-II these are converted to kg/(m * ships) and kg(hour*ships) resepectively when reading from DB, but here it might make more sense to keep the database units.