### PR TITLE
AER3-428 Added reference to the traditional lodging system if available

### DIFF
--- a/source/rest-service/src/main/resources/static/api.yaml
+++ b/source/rest-service/src/main/resources/static/api.yaml
@@ -443,6 +443,9 @@ components:
             scrubber:
               type: boolean
               description: Indication wether or not this lodging type makes use of an air scrubber ('luchtwasser')
+            traditionalLodgingSystem:
+              $ref: '#/components/schemas/Category'
+              description: Indicates the traditional lodging system that this system is linked to.
     FarmAdditionalLodgingSystemCategory:
       allOf:
         - $ref: '#/components/schemas/Category'


### PR DESCRIPTION
This reference is sometimes needed to get to the correct emission factor: If a lodging system without scrubber has a emissionfactor smaller than 0.3 * the emission factor of the linked traditional lodging system, and other reductive systems are used that DO include a scrubber, the emission factor is constrained to be 0.3 * the emission factor of the linked traditional lodging system. Take note that the webservice currently does NOT explain this.