### PR TITLE
AER3-429 Standard road emission factors

### DIFF
--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/controller/ErrorController.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/controller/ErrorController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.aerius.emissionservice.controller;
+
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.servlet.error.BasicErrorController;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * Controller to ensure errors get handled properly.
+ * Without this, errors won't be properly picked up because the DatasetsResource will be inspected for an /error mapping, which isn't there.
+ */
+@Controller
+@RequestMapping("${openapi.aERIUSEmissionService.base-path:/api/v1}")
+public class ErrorController extends BasicErrorController {
+
+  public ErrorController(final ErrorAttributes errorAttributes, final ServerProperties serverProperties) {
+    super(errorAttributes, serverProperties.getError());
+  }
+
+  @Override
+  @GetMapping(value = "/error", produces = {"application/json"})
+  public ResponseEntity<Map<String, Object>> error(final HttpServletRequest request) {
+    return super.error(request);
+  }
+
+}

--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/repository/RoadRepository.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/repository/RoadRepository.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.emissionservice.repository;
+
+import static nl.overheid.aerius.emissionservice.jooq.public_.tables.Substances.SUBSTANCES;
+import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadCategories.ROAD_CATEGORIES;
+import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadCategoriesView.ROAD_CATEGORIES_VIEW;
+import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadSpeedProfiles.ROAD_SPEED_PROFILES;
+import static org.jooq.impl.DSL.boolOr;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.trueCondition;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.springframework.stereotype.Repository;
+
+import nl.overheid.aerius.emissionservice.jooq.public_.enums.RoadType;
+import nl.overheid.aerius.emissionservice.jooq.public_.enums.SpeedLimitEnforcementType;
+import nl.overheid.aerius.emissionservice.jooq.public_.enums.VehicleType;
+import nl.overheid.aerius.emissionservice.model.RoadEmissionFactor;
+import nl.overheid.aerius.emissionservice.model.RoadSpeedProfileCategory;
+import nl.overheid.aerius.emissionservice.model.RoadSpeedProfileCategory.SpeedLimitEnforcementEnum;
+
+@Repository
+public class RoadRepository {
+
+  private static final Field<Boolean> HAS_SRM_DISTINCTION = field("has_srm_distinction", Boolean.class);
+
+  private static final Field<String> SUBSTANCE = field("substance", String.class);
+  private static final Field<Double> FACTOR = field("factor", Double.class);
+  private static final Field<Double> STAGNATED_FACTOR = field("stagnated_factor", Double.class);
+
+  private final DatasetStore datasetStore;
+
+  public RoadRepository(final DatasetStore datasetStore) {
+    this.datasetStore = datasetStore;
+  }
+
+  public List<String> getVehicleTypes() {
+    return datasetStore.dsl().selectDistinct(
+        ROAD_CATEGORIES.VEHICLE_TYPE)
+        .from(ROAD_CATEGORIES)
+        .orderBy(ROAD_CATEGORIES.VEHICLE_TYPE)
+        .fetchInto(String.class);
+  }
+
+  public List<String> getRoadTypes() {
+    return datasetStore.dsl().selectDistinct(
+        ROAD_SPEED_PROFILES.ROAD_TYPE)
+        .from(ROAD_SPEED_PROFILES)
+        .orderBy(ROAD_SPEED_PROFILES.ROAD_TYPE)
+        .fetchInto(String.class);
+  }
+
+  public List<RoadSpeedProfileCategory> getRoadSpeedProfiles(final Locale locale, final Optional<String> roadType,
+      final Optional<String> speedLimitEnforcement, final Optional<Boolean> srm2, final Optional<Boolean> srm1,
+      final Optional<Integer> maximumSpeed) {
+    // Separate select to determine which road types have a distinction for SRM1 and SRM2 in profiles.
+    final Map<RoadType, Boolean> srmDistinction = getSRMDistinctionPerRoadType();
+
+    Stream<RoadSpeedProfileCategory> categoriesStream = getRoadSpeedProfileCategories(srmDistinction, roadType, speedLimitEnforcement);
+    if (srm2.isPresent()) {
+      categoriesStream = categoriesStream.filter(category -> category.getUsableForSrm2() == srm2.get());
+    }
+    if (srm1.isPresent()) {
+      categoriesStream = categoriesStream.filter(category -> category.getUsableForSrm1() == srm1.get());
+    }
+    List<RoadSpeedProfileCategory> results = categoriesStream.collect(Collectors.toList());
+    if (maximumSpeed.isPresent()) {
+      results = determineCategoriesForSpeed(maximumSpeed.get(), results);
+    }
+    return results;
+  }
+
+  public List<RoadEmissionFactor> getEmissionFactors(final Locale locale, final String speedProfile, final String vehicleType,
+      final Integer year) {
+    final int speedProfileId;
+    final VehicleType dbVehicleType;
+    try {
+      speedProfileId = Integer.parseInt(speedProfile);
+      dbVehicleType = VehicleType.valueOf(vehicleType.toLowerCase(locale));
+    } catch (final IllegalArgumentException e) {
+      return Collections.emptyList();
+    }
+    return datasetStore.dsl()
+        .select(
+            SUBSTANCES.NAME.as(SUBSTANCE),
+            ROAD_CATEGORIES_VIEW.EMISSION_FACTOR.as(FACTOR),
+            ROAD_CATEGORIES_VIEW.STAGNATED_EMISSION_FACTOR.as(STAGNATED_FACTOR))
+        .from(ROAD_CATEGORIES_VIEW)
+        .innerJoin(SUBSTANCES).using(ROAD_CATEGORIES_VIEW.SUBSTANCE_ID)
+        .where(ROAD_CATEGORIES_VIEW.ROAD_SPEED_PROFILE_ID.eq(speedProfileId))
+        .and(ROAD_CATEGORIES_VIEW.VEHICLE_TYPE.eq(dbVehicleType))
+        .and(ROAD_CATEGORIES_VIEW.YEAR.eq((short) year.intValue()))
+        .fetchInto(RoadEmissionFactor.class);
+  }
+
+  private Map<RoadType, Boolean> getSRMDistinctionPerRoadType() {
+    return datasetStore.dsl().select(
+        ROAD_SPEED_PROFILES.ROAD_TYPE,
+        field(trueCondition()
+            .and(boolOr(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.equal(SpeedLimitEnforcementType.irrelevant)))
+            .and(boolOr(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.notEqual(SpeedLimitEnforcementType.irrelevant)))).as(HAS_SRM_DISTINCTION))
+        .from(ROAD_SPEED_PROFILES)
+        .groupBy(ROAD_SPEED_PROFILES.ROAD_TYPE)
+        .fetch()
+        .intoMap(ROAD_SPEED_PROFILES.ROAD_TYPE, HAS_SRM_DISTINCTION);
+  }
+
+  private Stream<RoadSpeedProfileCategory> getRoadSpeedProfileCategories(final Map<RoadType, Boolean> srmDistinction,
+      final Optional<String> roadType, final Optional<String> speedLimitEnforcement) {
+    final Result<Record> results = datasetStore.dsl()
+        .select()
+        .from(ROAD_SPEED_PROFILES)
+        .where(roadType.isPresent()
+            ? ROAD_SPEED_PROFILES.ROAD_TYPE.cast(String.class).eq(roadType.get().toLowerCase())
+            : trueCondition())
+        .and(speedLimitEnforcement.isPresent()
+            ? ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.cast(String.class).eq(speedLimitEnforcement.get().toLowerCase())
+            : trueCondition())
+        .fetch();
+    return results.stream().map(record -> {
+      final RoadType categoryRoadType = record.get(ROAD_SPEED_PROFILES.ROAD_TYPE);
+      final boolean usableForSrm1 = !srmDistinction.get(categoryRoadType)
+          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) == SpeedLimitEnforcementType.irrelevant;
+      final boolean usableForSrm2 = !srmDistinction.get(categoryRoadType)
+          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) != SpeedLimitEnforcementType.irrelevant;
+      return new RoadSpeedProfileCategory().code(record.get(ROAD_SPEED_PROFILES.ROAD_SPEED_PROFILE_ID).toString())
+          .name(record.get(ROAD_SPEED_PROFILES.NAME))
+          .description(categoryRoadType.name() + ", " + record.get(ROAD_SPEED_PROFILES.NAME))
+          .roadType(categoryRoadType.name())
+          .speedLimitEnforcement(SpeedLimitEnforcementEnum.fromValue(record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT).name()))
+          .usableForSrm1(usableForSrm1)
+          .usableForSrm2(usableForSrm2)
+          .maximumSpeed(record.get(ROAD_SPEED_PROFILES.MAXIMUM_SPEED));
+    });
+  }
+
+  private List<RoadSpeedProfileCategory> determineCategoriesForSpeed(final int targetMaxSpeed,
+      final List<RoadSpeedProfileCategory> originalCategories) {
+    final List<RoadSpeedProfileCategory> categoriesWithMaxSpeed = originalCategories.stream()
+        .filter(category -> category.getMaximumSpeed() != null)
+        .collect(Collectors.toList());
+    //if there are no categories with a maximum speed, just return those.
+    if (categoriesWithMaxSpeed.isEmpty()) {
+      return originalCategories;
+    } else {
+      final int maxSpeedFound = categoriesWithMaxSpeed.stream()
+          .mapToInt(category -> category.getMaximumSpeed().intValue())
+          // Find all speeds that are equal to or above our target speed
+          .filter(speed -> targetMaxSpeed <= speed)
+          // Get the minimum of those speeds as the speed that we want to retrieve categories for
+          .min()
+          // If none match the criteria (all speeds are below our target speed), use the highest of the speeds
+          .orElseGet(() -> categoriesWithMaxSpeed.stream()
+              .mapToInt(category -> category.getMaximumSpeed().intValue())
+              .max()
+              .getAsInt());
+      //Now return all the categories with that maximum speed.
+      return categoriesWithMaxSpeed.stream()
+          .filter(category -> category.getMaximumSpeed().intValue() == maxSpeedFound)
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/repository/RoadRepository.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/repository/RoadRepository.java
@@ -14,44 +14,34 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.overheid.aerius.emissionservice.repository;
+package nl.aerius.emissionservice.repository;
 
-import static nl.overheid.aerius.emissionservice.jooq.public_.tables.Substances.SUBSTANCES;
-import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadCategories.ROAD_CATEGORIES;
-import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadCategoriesView.ROAD_CATEGORIES_VIEW;
-import static nl.overheid.aerius.emissionservice.jooq.template.tables.RoadSpeedProfiles.ROAD_SPEED_PROFILES;
-import static org.jooq.impl.DSL.boolOr;
+import static nl.aerius.emissionservice.db.generated.template.tables.I18nRoadAreaCategories.I18N_ROAD_AREA_CATEGORIES;
+import static nl.aerius.emissionservice.db.generated.template.tables.I18nRoadTypeCategories.I18N_ROAD_TYPE_CATEGORIES;
+import static nl.aerius.emissionservice.db.generated.template.tables.I18nRoadVehicleCategories.I18N_ROAD_VEHICLE_CATEGORIES;
+import static nl.aerius.emissionservice.db.generated.template.tables.RoadAreaCategories.ROAD_AREA_CATEGORIES;
+import static nl.aerius.emissionservice.db.generated.template.tables.RoadTypeCategories.ROAD_TYPE_CATEGORIES;
+import static nl.aerius.emissionservice.db.generated.template.tables.RoadVehicleCategories.ROAD_VEHICLE_CATEGORIES;
+import static org.jooq.impl.DSL.coalesce;
 import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.trueCondition;
+import static org.jooq.impl.DSL.select;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jooq.Field;
-import org.jooq.Record;
-import org.jooq.Result;
 import org.springframework.stereotype.Repository;
 
-import nl.overheid.aerius.emissionservice.jooq.public_.enums.RoadType;
-import nl.overheid.aerius.emissionservice.jooq.public_.enums.SpeedLimitEnforcementType;
-import nl.overheid.aerius.emissionservice.jooq.public_.enums.VehicleType;
-import nl.overheid.aerius.emissionservice.model.RoadEmissionFactor;
-import nl.overheid.aerius.emissionservice.model.RoadEmissionFactors;
-import nl.overheid.aerius.emissionservice.model.RoadSpeedProfileCategory;
-import nl.overheid.aerius.emissionservice.model.RoadSpeedProfileCategory.SpeedLimitEnforcementEnum;
+import nl.aerius.emissionservice.db.generated.i18n.enums.LanguageCodeType;
+import nl.aerius.emissionservice.model.Category;
+import nl.aerius.emissionservice.model.RoadEmissionFactors;
 
 @Repository
 public class RoadRepository {
 
-  private static final Field<Boolean> HAS_SRM_DISTINCTION = field("has_srm_distinction", Boolean.class);
-
-  private static final Field<String> SUBSTANCE = field("substance", String.class);
-  private static final Field<Double> FACTOR = field("factor", Double.class);
-  private static final Field<Double> STAGNATED_FACTOR = field("stagnated_factor", Double.class);
+  private static final Field<String> DESCRIPTION = field("description", String.class);
+  private static final Field<String> I18N_DESCRIPTION = field("i18n_description", String.class);
 
   private final DatasetStore datasetStore;
 
@@ -59,164 +49,58 @@ public class RoadRepository {
     this.datasetStore = datasetStore;
   }
 
-  public List<String> getVehicleTypes() {
-    return datasetStore.dsl().selectDistinct(
-        ROAD_CATEGORIES.VEHICLE_TYPE)
-        .from(ROAD_CATEGORIES)
-        .orderBy(ROAD_CATEGORIES.VEHICLE_TYPE)
-        .fetchInto(String.class);
-  }
-
-  public List<String> getRoadTypes() {
-    return datasetStore.dsl().selectDistinct(
-        ROAD_SPEED_PROFILES.ROAD_TYPE)
-        .from(ROAD_SPEED_PROFILES)
-        .orderBy(ROAD_SPEED_PROFILES.ROAD_TYPE)
-        .fetchInto(String.class);
-  }
-
-  public List<RoadSpeedProfileCategory> getRoadSpeedProfiles(final Locale locale, final Optional<String> roadType,
-      final Optional<String> speedLimitEnforcement, final Optional<Boolean> srm2, final Optional<Boolean> srm1,
-      final Optional<Integer> maximumSpeed) {
-    // Separate select to determine which road types have a distinction for SRM1 and SRM2 in profiles.
-    final Map<RoadType, Boolean> srmDistinction = getSRMDistinctionPerRoadType();
-
-    Stream<RoadSpeedProfileCategory> categoriesStream = getRoadSpeedProfileCategories(srmDistinction, roadType, speedLimitEnforcement);
-    if (srm2.isPresent()) {
-      categoriesStream = categoriesStream.filter(category -> category.getUsableForSrm2() == srm2.get());
-    }
-    if (srm1.isPresent()) {
-      categoriesStream = categoriesStream.filter(category -> category.getUsableForSrm1() == srm1.get());
-    }
-    List<RoadSpeedProfileCategory> results = categoriesStream.collect(Collectors.toList());
-    if (maximumSpeed.isPresent()) {
-      results = determineCategoriesForSpeed(maximumSpeed.get(), results);
-    }
-    return results;
-  }
-
-  public Optional<RoadEmissionFactors> getEmissionFactors(final Locale locale, final String speedProfile, final String vehicleType,
-      final Integer year) {
-    final int speedProfileId;
-    final VehicleType dbVehicleType;
-    try {
-      speedProfileId = Integer.parseInt(speedProfile);
-      dbVehicleType = VehicleType.valueOf(vehicleType.toLowerCase(locale));
-    } catch (final IllegalArgumentException e) {
-      return Optional.empty();
-    }
-    final Optional<RoadSpeedProfileCategory> speedProfileCategory = getRoadSpeedProfileCategory(speedProfileId);
-    return speedProfileCategory.map(category -> new RoadEmissionFactors()
-        .year(year)
-        .vehicleType(vehicleType)
-        .roadSpeedProfileCategory(category)
-        .emissionFactors(getEmissionFactors(locale, speedProfileId, dbVehicleType, year)));
-  }
-
-  private List<RoadEmissionFactor> getEmissionFactors(final Locale locale, final int speedProfileId, final VehicleType vehicleType,
-      final Integer year) {
-    return datasetStore.dsl()
-        .select(
-            SUBSTANCES.NAME.as(SUBSTANCE),
-            ROAD_CATEGORIES_VIEW.EMISSION_FACTOR.as(FACTOR),
-            ROAD_CATEGORIES_VIEW.STAGNATED_EMISSION_FACTOR.as(STAGNATED_FACTOR))
-        .from(ROAD_CATEGORIES_VIEW)
-        .innerJoin(SUBSTANCES).using(ROAD_CATEGORIES_VIEW.SUBSTANCE_ID)
-        .where(ROAD_CATEGORIES_VIEW.ROAD_SPEED_PROFILE_ID.eq(speedProfileId))
-        .and(ROAD_CATEGORIES_VIEW.VEHICLE_TYPE.eq(vehicleType))
-        .and(ROAD_CATEGORIES_VIEW.YEAR.eq((short) year.intValue()))
-        .fetchInto(RoadEmissionFactor.class);
-  }
-
-  private Map<RoadType, Boolean> getSRMDistinctionPerRoadType() {
+  public List<Category> getRoadAreas(final Locale locale) {
+    final LanguageCodeType language = DbUtil.getLanguageCodeType(locale);
     return datasetStore.dsl().select(
-        ROAD_SPEED_PROFILES.ROAD_TYPE,
-        field(trueCondition()
-            .and(boolOr(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.equal(SpeedLimitEnforcementType.irrelevant)))
-            .and(boolOr(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.notEqual(SpeedLimitEnforcementType.irrelevant)))).as(HAS_SRM_DISTINCTION))
-        .from(ROAD_SPEED_PROFILES)
-        .groupBy(ROAD_SPEED_PROFILES.ROAD_TYPE)
-        .fetch()
-        .intoMap(ROAD_SPEED_PROFILES.ROAD_TYPE, HAS_SRM_DISTINCTION);
+        ROAD_AREA_CATEGORIES.CODE,
+        ROAD_AREA_CATEGORIES.NAME,
+        coalesce(I18N_DESCRIPTION, ROAD_AREA_CATEGORIES.NAME).as(DESCRIPTION))
+        .from(ROAD_AREA_CATEGORIES)
+        .leftJoin(
+            select(I18N_ROAD_AREA_CATEGORIES.ROAD_AREA_CATEGORY_ID, I18N_ROAD_AREA_CATEGORIES.DESCRIPTION.as(I18N_DESCRIPTION))
+                .from(I18N_ROAD_AREA_CATEGORIES)
+                .where(I18N_ROAD_AREA_CATEGORIES.LANGUAGE_CODE.eq(language)))
+        .using(ROAD_AREA_CATEGORIES.ROAD_AREA_CATEGORY_ID)
+        .orderBy(ROAD_AREA_CATEGORIES.CODE)
+        .fetchInto(Category.class);
   }
 
-  private Stream<RoadSpeedProfileCategory> getRoadSpeedProfileCategories(final Map<RoadType, Boolean> srmDistinction,
-      final Optional<String> roadType, final Optional<String> speedLimitEnforcement) {
-    final Result<Record> results = datasetStore.dsl()
-        .select()
-        .from(ROAD_SPEED_PROFILES)
-        .where(roadType.isPresent()
-            ? ROAD_SPEED_PROFILES.ROAD_TYPE.cast(String.class).eq(roadType.get().toLowerCase())
-            : trueCondition())
-        .and(speedLimitEnforcement.isPresent()
-            ? ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT.cast(String.class).eq(speedLimitEnforcement.get().toLowerCase())
-            : trueCondition())
-        .fetch();
-    return results.stream().map(record -> {
-      final RoadType categoryRoadType = record.get(ROAD_SPEED_PROFILES.ROAD_TYPE);
-      final boolean usableForSrm1 = !srmDistinction.get(categoryRoadType)
-          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) == SpeedLimitEnforcementType.irrelevant;
-      final boolean usableForSrm2 = !srmDistinction.get(categoryRoadType)
-          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) != SpeedLimitEnforcementType.irrelevant;
-      return new RoadSpeedProfileCategory().code(record.get(ROAD_SPEED_PROFILES.ROAD_SPEED_PROFILE_ID).toString())
-          .name(record.get(ROAD_SPEED_PROFILES.NAME))
-          .description(categoryRoadType.name() + ", " + record.get(ROAD_SPEED_PROFILES.NAME))
-          .roadType(categoryRoadType.name())
-          .speedLimitEnforcement(SpeedLimitEnforcementEnum.fromValue(record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT).name()))
-          .usableForSrm1(usableForSrm1)
-          .usableForSrm2(usableForSrm2)
-          .maximumSpeed(record.get(ROAD_SPEED_PROFILES.MAXIMUM_SPEED));
-    });
+  public List<Category> getRoadTypes(final Locale locale) {
+    final LanguageCodeType language = DbUtil.getLanguageCodeType(locale);
+    return datasetStore.dsl().select(
+        ROAD_TYPE_CATEGORIES.CODE,
+        ROAD_TYPE_CATEGORIES.NAME,
+        coalesce(I18N_DESCRIPTION, ROAD_TYPE_CATEGORIES.NAME).as(DESCRIPTION))
+        .from(ROAD_TYPE_CATEGORIES)
+        .leftJoin(
+            select(I18N_ROAD_TYPE_CATEGORIES.ROAD_TYPE_CATEGORY_ID, I18N_ROAD_TYPE_CATEGORIES.DESCRIPTION.as(I18N_DESCRIPTION))
+                .from(I18N_ROAD_TYPE_CATEGORIES)
+                .where(I18N_ROAD_TYPE_CATEGORIES.LANGUAGE_CODE.eq(language)))
+        .using(ROAD_TYPE_CATEGORIES.ROAD_TYPE_CATEGORY_ID)
+        .orderBy(ROAD_TYPE_CATEGORIES.CODE)
+        .fetchInto(Category.class);
   }
 
-  private List<RoadSpeedProfileCategory> determineCategoriesForSpeed(final int targetMaxSpeed,
-      final List<RoadSpeedProfileCategory> originalCategories) {
-    final List<RoadSpeedProfileCategory> categoriesWithMaxSpeed = originalCategories.stream()
-        .filter(category -> category.getMaximumSpeed() != null)
-        .collect(Collectors.toList());
-    //if there are no categories with a maximum speed, just return those.
-    if (categoriesWithMaxSpeed.isEmpty()) {
-      return originalCategories;
-    } else {
-      final int maxSpeedFound = categoriesWithMaxSpeed.stream()
-          .mapToInt(category -> category.getMaximumSpeed().intValue())
-          // Find all speeds that are equal to or above our target speed
-          .filter(speed -> targetMaxSpeed <= speed)
-          // Get the minimum of those speeds as the speed that we want to retrieve categories for
-          .min()
-          // If none match the criteria (all speeds are below our target speed), use the highest of the speeds
-          .orElseGet(() -> categoriesWithMaxSpeed.stream()
-              .mapToInt(category -> category.getMaximumSpeed().intValue())
-              .max()
-              .getAsInt());
-      //Now return all the categories with that maximum speed.
-      return categoriesWithMaxSpeed.stream()
-          .filter(category -> category.getMaximumSpeed().intValue() == maxSpeedFound)
-          .collect(Collectors.toList());
-    }
+  public List<Category> getVehicleTypes(final Locale locale) {
+    final LanguageCodeType language = DbUtil.getLanguageCodeType(locale);
+    return datasetStore.dsl().select(
+        ROAD_VEHICLE_CATEGORIES.CODE,
+        ROAD_VEHICLE_CATEGORIES.NAME,
+        coalesce(I18N_DESCRIPTION, ROAD_VEHICLE_CATEGORIES.NAME).as(DESCRIPTION))
+        .from(ROAD_VEHICLE_CATEGORIES)
+        .leftJoin(
+            select(I18N_ROAD_VEHICLE_CATEGORIES.ROAD_VEHICLE_CATEGORY_ID, I18N_ROAD_VEHICLE_CATEGORIES.DESCRIPTION.as(I18N_DESCRIPTION))
+                .from(I18N_ROAD_VEHICLE_CATEGORIES)
+                .where(I18N_ROAD_VEHICLE_CATEGORIES.LANGUAGE_CODE.eq(language)))
+        .using(ROAD_VEHICLE_CATEGORIES.ROAD_VEHICLE_CATEGORY_ID)
+        .orderBy(ROAD_VEHICLE_CATEGORIES.CODE)
+        .fetchInto(Category.class);
   }
 
-  private Optional<RoadSpeedProfileCategory> getRoadSpeedProfileCategory(final int speedProfileId) {
-    final Optional<Record> result = datasetStore.dsl()
-        .select()
-        .from(ROAD_SPEED_PROFILES)
-        .where(ROAD_SPEED_PROFILES.ROAD_SPEED_PROFILE_ID.eq(speedProfileId))
-        .fetchOptional();
-    final Map<RoadType, Boolean> srmDistinction = getSRMDistinctionPerRoadType();
-    return result.map(record -> {
-      final RoadType categoryRoadType = record.get(ROAD_SPEED_PROFILES.ROAD_TYPE);
-      final boolean usableForSrm1 = !srmDistinction.get(categoryRoadType)
-          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) == SpeedLimitEnforcementType.irrelevant;
-      final boolean usableForSrm2 = !srmDistinction.get(categoryRoadType)
-          || record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT) != SpeedLimitEnforcementType.irrelevant;
-      return new RoadSpeedProfileCategory().code(record.get(ROAD_SPEED_PROFILES.ROAD_SPEED_PROFILE_ID).toString())
-          .name(record.get(ROAD_SPEED_PROFILES.NAME))
-          .description(categoryRoadType.name() + ", " + record.get(ROAD_SPEED_PROFILES.NAME))
-          .roadType(categoryRoadType.name())
-          .speedLimitEnforcement(SpeedLimitEnforcementEnum.fromValue(record.get(ROAD_SPEED_PROFILES.SPEED_LIMIT_ENFORCEMENT).name()))
-          .usableForSrm1(usableForSrm1)
-          .usableForSrm2(usableForSrm2)
-          .maximumSpeed(record.get(ROAD_SPEED_PROFILES.MAXIMUM_SPEED));
-    });
+  public Optional<List<RoadEmissionFactors>> getEmissionFactors(final Locale locale, final String roadArea, final String roadType,
+      final String vehicleType, final Integer year) {
+    // TODO: get all emission factors for requested combination
+    return Optional.empty();
   }
+
 }

--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -37,10 +36,12 @@ import nl.aerius.emissionservice.model.FarmAdditionalLodgingSystemCategory;
 import nl.aerius.emissionservice.model.FarmFodderMeasureCategory;
 import nl.aerius.emissionservice.model.FarmLodgingCategory;
 import nl.aerius.emissionservice.model.FarmReductiveLodgingSystemCategory;
+import nl.aerius.emissionservice.model.RoadEmissionFactors;
 import nl.aerius.emissionservice.model.Sector;
 import nl.aerius.emissionservice.repository.DatasetStore;
 import nl.aerius.emissionservice.repository.FarmRepository;
 import nl.aerius.emissionservice.repository.FarmlandRepository;
+import nl.aerius.emissionservice.repository.RoadRepository;
 import nl.aerius.emissionservice.repository.SectorRepository;
 
 @Service
@@ -160,34 +161,25 @@ public class DatasetsResource implements DatasetsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<List<String>> listVehicleTypes(final String dataset, final Optional<String> acceptLanguage) {
-    return handle(dataset, acceptLanguage, roadRepository::getVehicleTypes);
+  public ResponseEntity<List<Category>> listRoadAreas(final String dataset, final Optional<String> acceptLanguage) {
+    return handle(dataset, acceptLanguage, roadRepository::getRoadAreas);
   }
 
   @Override
-  public ResponseEntity<List<String>> listRoadTypes(final String dataset, final Optional<String> acceptLanguage) {
+  public ResponseEntity<List<Category>> listRoadTypes(final String dataset, final Optional<String> acceptLanguage) {
     return handle(dataset, acceptLanguage, roadRepository::getRoadTypes);
   }
 
   @Override
-  public ResponseEntity<List<RoadSpeedProfileCategory>> listSpeedProfiles(final String dataset, final Optional<String> acceptLanguage,
-      final Optional<String> roadtype, final Optional<String> speedlimitenforcement, final Optional<Boolean> srm2,
-      final Optional<Boolean> srm1, final Optional<Integer> maximumspeed) {
-    return handle(dataset, acceptLanguage,
-        locale -> roadRepository.getRoadSpeedProfiles(locale, roadtype, speedlimitenforcement, srm2, srm1, maximumspeed));
+  public ResponseEntity<List<Category>> listVehicleTypes(final String dataset, final Optional<String> acceptLanguage) {
+    return handle(dataset, acceptLanguage, roadRepository::getVehicleTypes);
   }
 
   @Override
-  public ResponseEntity<RoadEmissionFactors> getRoadEmissionFactors(final String dataset, final String speedprofile, final String vehicletype,
-      final Integer year, final Optional<String> acceptLanguage) {
-    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(locale, speedprofile, vehicletype, year).orElseThrow(
+  public ResponseEntity<List<RoadEmissionFactors>> getRoadEmissionFactors(final String dataset, final String roadarea, final String roadtype,
+      final String vehicletype, final Integer year, final Optional<String> acceptLanguage) {
+    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(locale, roadarea, roadtype, vehicletype, year).orElseThrow(
         () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find road emission factors for supplied parameters")));
-  }
-
-  private <T> ResponseEntity<T> handle(final String dataset, final Optional<String> acceptLanguage, final Supplier<T> function) {
-    final String actualDataset = handleDataset(dataset);
-    final T result = function.get();
-    return toOkResponse(actualDataset, result);
   }
 
   private <T> ResponseEntity<T> handle(final String dataset, final Optional<String> acceptLanguage, final Function<Locale, T> function) {

--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
@@ -178,9 +178,10 @@ public class DatasetsResource implements DatasetsApiDelegate {
   }
 
   @Override
-  public ResponseEntity<List<RoadEmissionFactor>> getRoadEmissionFactors(final String dataset, final String speedprofile, final String vehicletype,
+  public ResponseEntity<RoadEmissionFactors> getRoadEmissionFactors(final String dataset, final String speedprofile, final String vehicletype,
       final Integer year, final Optional<String> acceptLanguage) {
-    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(locale, speedprofile, vehicletype, year));
+    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(locale, speedprofile, vehicletype, year).orElseThrow(
+        () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find road emission factors for supplied parameters")));
   }
 
   private <T> ResponseEntity<T> handle(final String dataset, final Optional<String> acceptLanguage, final Supplier<T> function) {

--- a/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
+++ b/source/rest-service/src/main/java/nl/aerius/emissionservice/resource/DatasetsResource.java
@@ -178,7 +178,7 @@ public class DatasetsResource implements DatasetsApiDelegate {
   @Override
   public ResponseEntity<List<RoadEmissionFactors>> getRoadEmissionFactors(final String dataset, final String roadarea, final String roadtype,
       final String vehicletype, final Integer year, final Optional<String> acceptLanguage) {
-    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(locale, roadarea, roadtype, vehicletype, year).orElseThrow(
+    return handle(dataset, acceptLanguage, locale -> roadRepository.getEmissionFactors(roadarea, roadtype, vehicletype, year).orElseThrow(
         () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find road emission factors for supplied parameters")));
   }
 

--- a/source/rest-service/src/main/resources/application.properties
+++ b/source/rest-service/src/main/resources/application.properties
@@ -3,9 +3,8 @@ spring.datasource.url=jdbc:postgresql://localhost/emissions
 #spring.datasource.username=
 #spring.datasource.password=
 
-server.error.whitelabel.enabled=false
 server.error.include-message=always
 
+# Ensure everything is served under /api/v1/
 spring.mvc.servlet.path=/api/v1/
-
 openapi.aERIUSEmissionService.base-path=/

--- a/source/rest-service/src/main/resources/application.properties
+++ b/source/rest-service/src/main/resources/application.properties
@@ -8,3 +8,6 @@ server.error.include-message=always
 # Ensure everything is served under /api/v1/
 spring.mvc.servlet.path=/api/v1/
 openapi.aERIUSEmissionService.base-path=/
+
+# Don't include null values in json objects
+spring.jackson.default-property-inclusion=non_null

--- a/source/rest-service/src/main/resources/static/api.yaml
+++ b/source/rest-service/src/main/resources/static/api.yaml
@@ -35,6 +35,8 @@ tags:
   description: Sector specific information
 - name: farming
   description: Farm specific information
+- name: roads
+  description: Road specific information
 paths:
   /datasets:
     get:
@@ -350,6 +352,142 @@ paths:
         404:
           description: Supplied dataset not found.
           content: {}
+  /datasets/{dataset}/road/vehicletypes:
+    get:
+      summary: List all vehicle types
+      operationId: listVehicleTypes
+      tags:
+        - roads
+      parameters:
+        - $ref: '#/components/parameters/datasetParam'
+        - $ref: '#/components/parameters/languageHeader'
+      responses:
+        200:
+          description: A list of possible vehicle types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  description: Unique code for the vehicle type
+        404:
+          description: Supplied dataset not found.
+          content: {}
+  /datasets/{dataset}/road/roadtypes:
+    get:
+      summary: List all road types
+      operationId: listRoadTypes
+      tags:
+        - roads
+      parameters:
+        - $ref: '#/components/parameters/datasetParam'
+        - $ref: '#/components/parameters/languageHeader'
+      responses:
+        200:
+          description: A list of possible road types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                  description: Unique code for the vehicle type
+        404:
+          description: Supplied dataset not found.
+          content: {}
+  /datasets/{dataset}/road/speedprofiles:
+    get:
+      summary: List all speed profiles
+      operationId: listSpeedProfiles
+      tags:
+        - roads
+      parameters:
+        - $ref: '#/components/parameters/datasetParam'
+        - $ref: '#/components/parameters/languageHeader'
+        - name: roadtype
+          in: query
+          description: filter for a specific road type.
+          required: false
+          schema:
+            type: string
+        - name: speedlimitenforcement
+          in: query
+          description: filter for a specific speed limit enforcement.
+          required: false
+          schema:
+            type: string
+        - name: srm2
+          in: query
+          description: filter for speed profiles usable for srm2 calculations.
+          required: false
+          schema:
+            type: boolean
+        - name: srm1
+          in: query
+          description: filter for speed profiles usable for srm1 calculations.
+          required: false
+          schema:
+            type: boolean
+        - name: maximumspeed
+          in: query
+          description: filter for speed profile that best matches the maximum speed.
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: A list of possible speed profiles
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RoadSpeedProfileCategory"
+        404:
+          description: Supplied dataset not found.
+          content: {}
+  /datasets/{dataset}/road/speedprofile/{speedprofile}/vehicletype/{vehicletype}/year/{year}:
+    get:
+      summary: Retrieve emission factors for road
+      operationId: getRoadEmissionFactors
+      tags:
+        - roads
+      parameters:
+        - $ref: '#/components/parameters/datasetParam'
+        - $ref: '#/components/parameters/languageHeader'
+        - name: speedprofile
+          in: path
+          description: Which speed profile to retrieve for.
+          required: true
+          schema:
+            type: string
+        - name: vehicletype
+          in: path
+          description: Which vehicle type to retrieve for.
+          required: true
+          schema:
+            type: string
+        - name: year
+          in: path
+          description: Which year to retrieve for.
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        200:
+          description: The road category with emission factors that can be used.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RoadEmissionFactor"
+        404:
+          description: Supplied dataset not found.
+          content: {}
 components:
   parameters:
     datasetParam:
@@ -586,6 +724,34 @@ components:
         fractionCellar:
           type: number
           description: The fraction of the emission originating from the cellar (or manure pit).
+    RoadSpeedProfileCategory:
+      allOf:
+        - $ref: '#/components/schemas/Category'
+        - description: A category for a road speed profile.
+        - type: object
+          required:
+            - roadType
+            - usableForSrm1
+            - usableForSrm2
+            - speedLimitEnforcement
+          properties:
+            roadType:
+              type: string
+              description: The road type that this profile applies to.
+            usableForSrm1:
+              type: boolean
+              description: Indicates if the speed profile can be used for SRM1 calculations.
+            usableForSrm2:
+              type: boolean
+              description: Indicates if the speed profile can be used for SRM2 calculations.
+            speedLimitEnforcement:
+              type: string
+              description: Indicates if maximum speed is a factor for this speed profile, and if that maximum speed is enforced strictly (by means of a 'trajectcontrole' for instance).
+              enum: [irrelevant, not_strict, strict]
+            maximumSpeed:
+              type: integer
+              format: int32
+              description: the maximum speed for this speed profile in cases where that matters.
     EmissionFactor:
       type: object
       required:
@@ -610,3 +776,18 @@ components:
         fraction:
           type: number
           description: The fraction of emission.
+    RoadEmissionFactor:
+      type: object
+      required:
+        - substance
+        - factor
+      properties:
+        substance:
+          type: string
+          description: The substance that the emission factor is for.
+        factor:
+          type: number
+          description: The factor of emission per g/vehicle/km to be used for vehicles under free flow.
+        stagnatedFactor:
+          type: number
+          description: The factor of emission per g/vehicle/km to be used for vehicles that are considered stagnated..

--- a/source/rest-service/src/main/resources/static/api.yaml
+++ b/source/rest-service/src/main/resources/static/api.yaml
@@ -430,9 +430,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/RoadEmissionFactor"
+                $ref: "#/components/schemas/RoadEmissionFactors"
         404:
           $ref: '#/components/responses/NotFound'
 components:
@@ -714,6 +712,27 @@ components:
               type: integer
               format: int32
               description: the maximum speed for this speed profile in cases where that matters.
+    RoadEmissionFactors:
+      type: object
+      description: Category for road.
+      required:
+        - roadSpeedProfileCategory
+        - vehicleType
+        - year
+      properties:
+        roadSpeedProfileCategory:
+          $ref: "#/components/schemas/RoadSpeedProfileCategory"
+        vehicleType:
+          type: string
+          description: The vehicle type for the emission factors
+        year:
+          type: integer
+          format: int32
+          description: The year for the emission factors
+        emissionFactors:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoadEmissionFactor"
     EmissionFactor:
       type: object
       required:

--- a/source/rest-service/src/main/resources/static/api.yaml
+++ b/source/rest-service/src/main/resources/static/api.yaml
@@ -72,8 +72,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Dataset"
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/sectors:
     get:
       summary: List all sectors
@@ -93,8 +92,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/Sector"
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/sectors/{code}:
     get:
       summary: Get specific sector information
@@ -118,8 +116,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Sector"
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/animals:
     get:
       summary: List all farm animal categories
@@ -131,16 +128,9 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible farm animal categories
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings:
     get:
       summary: List all farm lodging categories
@@ -158,16 +148,9 @@ paths:
             type: string
       responses:
         200:
-          description: A list of possible farm lodging categories
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/{code}:
     get:
       summary: Get specific farm lodging information
@@ -191,8 +174,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FarmLodgingCategory"
         404:
-          description: Supplied dataset or category not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/additionalsystems:
     get:
       summary: List all farm additional lodging systems
@@ -204,16 +186,9 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible farm additional lodging systems
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/additionalsystems/{code}:
     get:
       summary: Get specific farm additional lodging system
@@ -237,8 +212,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FarmAdditionalLodgingSystemCategory"
         404:
-          description: Supplied dataset or category not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/reductivesystems:
     get:
       summary: List all farm reductive lodging systems
@@ -250,16 +224,9 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible farm reductive lodging systems
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/reductivesystems/{code}:
     get:
       summary: Get specific farm reductive lodging system
@@ -283,8 +250,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FarmReductiveLodgingSystemCategory"
         404:
-          description: Supplied dataset or category not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/foddermeasures:
     get:
       summary: List all farm lodging fodder measures
@@ -296,16 +262,9 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible farm lodging fodder measures
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farm/lodgings/foddermeasures/{code}:
     get:
       summary: Get specific farm lodging fodder measure
@@ -329,8 +288,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/FarmFodderMeasureCategory"
         404:
-          description: Supplied dataset or category not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/farmlands:
     get:
       summary: List all farmland-related categories
@@ -342,16 +300,9 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible farmland categories
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/Category"
+          $ref: '#/components/responses/CategoriesList'
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/road/vehicletypes:
     get:
       summary: List all vehicle types
@@ -372,8 +323,7 @@ paths:
                   type: string
                   description: Unique code for the vehicle type
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/road/roadtypes:
     get:
       summary: List all road types
@@ -392,10 +342,9 @@ paths:
                 type: array
                 items:
                   type: string
-                  description: Unique code for the vehicle type
+                  description: Unique code for the road type
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/road/speedprofiles:
     get:
       summary: List all speed profiles
@@ -446,8 +395,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/RoadSpeedProfileCategory"
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/road/speedprofile/{speedprofile}/vehicletype/{vehicletype}/year/{year}:
     get:
       summary: Retrieve emission factors for road
@@ -486,8 +434,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/RoadEmissionFactor"
         404:
-          description: Supplied dataset not found.
-          content: {}
+          $ref: '#/components/responses/NotFound'
 components:
   parameters:
     datasetParam:
@@ -504,6 +451,21 @@ components:
       schema:
         type: string
       description:  Indication of which language to use. if not supplied or only unsupported languages are supplied, dutch will be used.
+
+  responses:
+    CategoriesList:
+      description: A list of possible categories
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Category"
+    NotFound:
+      description: |
+        Het opgegeven object kon niet worden gevonden.
+      content: {}
+
   schemas:
     Category:
       type: object

--- a/source/rest-service/src/main/resources/static/api.yaml
+++ b/source/rest-service/src/main/resources/static/api.yaml
@@ -303,10 +303,10 @@ paths:
           $ref: '#/components/responses/CategoriesList'
         404:
           $ref: '#/components/responses/NotFound'
-  /datasets/{dataset}/road/vehicletypes:
+  /datasets/{dataset}/road/roadareas:
     get:
-      summary: List all vehicle types
-      operationId: listVehicleTypes
+      summary: List all road areas
+      operationId: listRoadAreas
       tags:
         - roads
       parameters:
@@ -314,14 +314,7 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible vehicle types
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                  description: Unique code for the vehicle type
+          $ref: '#/components/responses/CategoriesList'
         404:
           $ref: '#/components/responses/NotFound'
   /datasets/{dataset}/road/roadtypes:
@@ -335,68 +328,24 @@ paths:
         - $ref: '#/components/parameters/languageHeader'
       responses:
         200:
-          description: A list of possible road types
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-                  description: Unique code for the road type
+          $ref: '#/components/responses/CategoriesList'
         404:
           $ref: '#/components/responses/NotFound'
-  /datasets/{dataset}/road/speedprofiles:
+  /datasets/{dataset}/road/vehicletypes:
     get:
-      summary: List all speed profiles
-      operationId: listSpeedProfiles
+      summary: List all vehicle types
+      operationId: listVehicleTypes
       tags:
         - roads
       parameters:
         - $ref: '#/components/parameters/datasetParam'
         - $ref: '#/components/parameters/languageHeader'
-        - name: roadtype
-          in: query
-          description: filter for a specific road type.
-          required: false
-          schema:
-            type: string
-        - name: speedlimitenforcement
-          in: query
-          description: filter for a specific speed limit enforcement.
-          required: false
-          schema:
-            type: string
-        - name: srm2
-          in: query
-          description: filter for speed profiles usable for srm2 calculations.
-          required: false
-          schema:
-            type: boolean
-        - name: srm1
-          in: query
-          description: filter for speed profiles usable for srm1 calculations.
-          required: false
-          schema:
-            type: boolean
-        - name: maximumspeed
-          in: query
-          description: filter for speed profile that best matches the maximum speed.
-          required: false
-          schema:
-            type: integer
-            format: int32
       responses:
         200:
-          description: A list of possible speed profiles
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/RoadSpeedProfileCategory"
+          $ref: '#/components/responses/CategoriesList'
         404:
           $ref: '#/components/responses/NotFound'
-  /datasets/{dataset}/road/speedprofile/{speedprofile}/vehicletype/{vehicletype}/year/{year}:
+  /datasets/{dataset}/road/area/{roadarea}/roadtype/{roadtype}/vehicletype/{vehicletype}/year/{year}:
     get:
       summary: Retrieve emission factors for road
       operationId: getRoadEmissionFactors
@@ -405,9 +354,15 @@ paths:
       parameters:
         - $ref: '#/components/parameters/datasetParam'
         - $ref: '#/components/parameters/languageHeader'
-        - name: speedprofile
+        - name: roadarea
           in: path
-          description: Which speed profile to retrieve for.
+          description: Which (road) area to retrieve for.
+          required: true
+          schema:
+            type: string
+        - name: roadtype
+          in: path
+          description: Which road type to retrieve for.
           required: true
           schema:
             type: string
@@ -430,7 +385,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoadEmissionFactors"
+                type: array
+                items:
+                  $ref: "#/components/schemas/RoadEmissionFactors"
         404:
           $ref: '#/components/responses/NotFound'
 components:
@@ -684,44 +641,21 @@ components:
         fractionCellar:
           type: number
           description: The fraction of the emission originating from the cellar (or manure pit).
-    RoadSpeedProfileCategory:
-      allOf:
-        - $ref: '#/components/schemas/Category'
-        - description: A category for a road speed profile.
-        - type: object
-          required:
-            - roadType
-            - usableForSrm1
-            - usableForSrm2
-            - speedLimitEnforcement
-          properties:
-            roadType:
-              type: string
-              description: The road type that this profile applies to.
-            usableForSrm1:
-              type: boolean
-              description: Indicates if the speed profile can be used for SRM1 calculations.
-            usableForSrm2:
-              type: boolean
-              description: Indicates if the speed profile can be used for SRM2 calculations.
-            speedLimitEnforcement:
-              type: string
-              description: Indicates if maximum speed is a factor for this speed profile, and if that maximum speed is enforced strictly (by means of a 'trajectcontrole' for instance).
-              enum: [irrelevant, not_strict, strict]
-            maximumSpeed:
-              type: integer
-              format: int32
-              description: the maximum speed for this speed profile in cases where that matters.
     RoadEmissionFactors:
       type: object
       description: Category for road.
       required:
-        - roadSpeedProfileCategory
+        - roadArea
+        - roadType
         - vehicleType
         - year
       properties:
-        roadSpeedProfileCategory:
-          $ref: "#/components/schemas/RoadSpeedProfileCategory"
+        roadArea:
+          type: string
+          description: The road area for the emission factors
+        roadType:
+          type: string
+          description: The road type for the emission factors
         vehicleType:
           type: string
           description: The vehicle type for the emission factors
@@ -729,6 +663,15 @@ components:
           type: integer
           format: int32
           description: The year for the emission factors
+        strictEnforcement:
+          type: boolean
+          description: Indication if these emission factors are for strict enforcement. If absent, assume false.
+        speed:
+          type: integer
+          description: The speed for the vehicles. Can be maximum speed or actual speed, depending on country. If not present, this is not of interest.
+        gradient:
+          type: integer
+          description: The gradient of the road. If not present, assume 0.
         emissionFactors:
           type: array
           items:


### PR DESCRIPTION
Methods to obtain the emission factors for the standard road categories (light traffic, medium freight, heavy freight and autobus).

This is quite different from farm lodgings, and isn't that straight forward: the speed profiles and different applications in SRM1/SRM2 (for non urban roads) make it complicated. The idea is to first pick a road type, then pick a speed profile based on that road type and some other properties, and use that along with the vehicle type and year to arrive at the correct emission factors.