### PR TITLE
Mobile_source_off_road: power to engine_capacity.

### DIFF
--- a/source/database/src/data/sql/nature2021/emission_factors/load.sql
+++ b/source/database/src/data/sql/nature2021/emission_factors/load.sql
@@ -36,7 +36,7 @@ BEGIN; SELECT setup.ae_load_table('nature2021.plan_category_emission_factors', '
 /* Mobile source data */
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_categories', '{data_folder}/public/mobile_source_off_road_categories_20200626.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_emission_factors', '{data_folder}/public/mobile_source_off_road_category_emission_factors_20210223.txt'); COMMIT;
-BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_idle_properties', '{data_folder}/public/mobile_source_off_road_category_idle_properties_20210223.txt'); COMMIT;
+BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_idle_properties', '{data_folder}/public/mobile_source_off_road_category_idle_properties_20210519.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_categories', '{data_folder}/public/mobile_source_on_road_categories_20150127.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_category_emission_factors', '{data_folder}/public/mobile_source_on_road_category_emission_factors_20200612.txt'); COMMIT;
 

--- a/source/database/src/main/sql/template/02-emission_factors/02-tables/mobile_sources.sql
+++ b/source/database/src/main/sql/template/02-emission_factors/02-tables/mobile_sources.sql
@@ -22,15 +22,15 @@ CREATE TABLE mobile_source_off_road_categories
  *
  * Niet voor alle stageklasses zijn stationaire emissieberekeningen mogelijk, in dat geval ontbreekt het record.
  *
- * @column power_min Vmin, minimaal vermogen binnen de opgegeven stage-klasse (KW)
- * @column power_max Vmax, maximaal vermogen binnen de opgegeven stage-klasse (KW)
+ * @column engine_capacity_min Clmin, minimale cilinder-inhoud binnen de opgegeven stage-klasse (KW)
+ * @column engine_capacity_max Clmax, maximale cilinder-inhoud binnen de opgegeven stage-klasse (KW)
  * @column fuel_consumption_idle GBS_plci, liter brandstof verbruik stationair per uur per liter cilinder-inhoud (l/l/uur)
  */
 CREATE TABLE mobile_source_off_road_category_idle_properties
 (
 	mobile_source_off_road_category_id smallint NOT NULL,
-	power_min posreal NOT NULL,
-	power_max posreal NOT NULL,
+	engine_capacity_min posreal NOT NULL,
+	engine_capacity_max posreal NOT NULL,
 	fuel_consumption_idle posreal NOT NULL,
 
 	CONSTRAINT mobile_source_off_road_category_idle_prop_pkey PRIMARY KEY (mobile_source_off_road_category_id),


### PR DESCRIPTION
Up till now, the minimum- and maximum engine capacity was calculated in the UI from the minimum- and maximum power output. Now, these calculated values are included in the mobile_source_off_road_category_idle_properties- table instead of the power-values.
AER3-646.