### PR TITLE
Actualisation mobile_source_on_road_categories and emission factors.

### DIFF
--- a/source/database/src/data/sql/nature2021/emission_factors/load.sql
+++ b/source/database/src/data/sql/nature2021/emission_factors/load.sql
@@ -37,8 +37,8 @@ BEGIN; SELECT setup.ae_load_table('nature2021.plan_category_emission_factors', '
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_categories', '{data_folder}/public/mobile_source_off_road_categories_20200626.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_emission_factors', '{data_folder}/public/mobile_source_off_road_category_emission_factors_20210223.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_idle_properties', '{data_folder}/public/mobile_source_off_road_category_idle_properties_20210223.txt'); COMMIT;
-BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_categories', '{data_folder}/public/mobile_source_on_road_categories_20150127.txt'); COMMIT;
-BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_category_emission_factors', '{data_folder}/public/mobile_source_on_road_category_emission_factors_20200612.txt'); COMMIT;
+BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_categories', '{data_folder}/public/mobile_source_on_road_categories_20210618.txt'); COMMIT;
+BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_category_emission_factors', '{data_folder}/public/mobile_source_on_road_category_emission_factors_TEMP2035_20210617.txt'); COMMIT;
 
 /* Shipping data */
 BEGIN; SELECT setup.ae_load_table('nature2021.shipping_maritime_categories', '{data_folder}/public/shipping_maritime_categories_20140331.txt'); COMMIT;

--- a/source/database/src/data/sql/nature2021/emission_factors/load.sql
+++ b/source/database/src/data/sql/nature2021/emission_factors/load.sql
@@ -38,7 +38,7 @@ BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_categories'
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_emission_factors', '{data_folder}/public/mobile_source_off_road_category_emission_factors_20210223.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_off_road_category_idle_properties', '{data_folder}/public/mobile_source_off_road_category_idle_properties_20210223.txt'); COMMIT;
 BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_categories', '{data_folder}/public/mobile_source_on_road_categories_20210618.txt'); COMMIT;
-BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_category_emission_factors', '{data_folder}/public/mobile_source_on_road_category_emission_factors_TEMP2035_20210617.txt'); COMMIT;
+BEGIN; SELECT setup.ae_load_table('nature2021.mobile_source_on_road_category_emission_factors', '{data_folder}/public/mobile_source_on_road_category_emission_factors_TEMP2035_20210630.txt'); COMMIT;
 
 /* Shipping data */
 BEGIN; SELECT setup.ae_load_table('nature2021.shipping_maritime_categories', '{data_folder}/public/shipping_maritime_categories_20140331.txt'); COMMIT;

--- a/source/database/src/main/sql/template/02-emission_factors/02-tables/mobile_sources.sql
+++ b/source/database/src/main/sql/template/02-emission_factors/02-tables/mobile_sources.sql
@@ -94,10 +94,11 @@ CREATE TABLE mobile_source_on_road_category_emission_factors
 (
 	mobile_source_on_road_category_id smallint NOT NULL,
 	road_type road_type NOT NULL,
+	year year_type NOT NULL,
 	substance_id smallint NOT NULL,
 	emission_factor posreal NOT NULL,
 
-	CONSTRAINT mobile_source_on_road_efac_pkey PRIMARY KEY (mobile_source_on_road_category_id, road_type, substance_id),
+	CONSTRAINT mobile_source_on_road_efac_pkey PRIMARY KEY (mobile_source_on_road_category_id, road_type, year, substance_id),
 	CONSTRAINT mobile_source_on_road_efac_fkey_substances FOREIGN KEY (substance_id) REFERENCES substances,
 	CONSTRAINT mobile_source_on_road_efac_fkey_mobile_on_road_cat FOREIGN KEY (mobile_source_on_road_category_id) REFERENCES mobile_source_on_road_categories
 );


### PR DESCRIPTION
Emission factors for on_road have to be selectec by year, so the "year"- column is added to the table "mobile_source_on_road_categories".
New import files are made:
- mobile_source_on_road_categories
- mobile_source_on_road_category_emission_factors

AER3-744.