### PR TITLE
Specify docker compose version as 3.10

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 
-version: "3"
+version: "3.10"
 
 services:
   database:


### PR DESCRIPTION
Should align the different yaml versions that are present in jenkins when composing.