### PR TITLE
Specify docker compose version as 3.8

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 #
 
-version: "3.10"
+version: "3.8"
 
 services:
   database:


### PR DESCRIPTION
Apparantly 3.10 is fake (something with Compose V1 and V2)